### PR TITLE
changing equation parameter to match function's math expression

### DIFF
--- a/docs/notebooks/Kamodo.ipynb
+++ b/docs/notebooks/Kamodo.ipynb
@@ -355,7 +355,7 @@
     "from kamodo import kamodofy, Kamodo\n",
     "import numpy as np\n",
     "\n",
-    "@kamodofy(units = 'kg/m**3', citation = 'Bob et. al, 2018', equation='xy')\n",
+    "@kamodofy(units = 'kg/m**3', citation = 'Bob et. al, 2018', equation='x+y') \n",
     "def rho(x = np.array([3,4,5]), y = np.array([1,2,3])):\n",
     "    \"\"\"A function that computes density\"\"\"\n",
     "    return x+y\n",


### PR DESCRIPTION
In the code block in the section on the "@kamodofy Decorator", the equation parameter is set to "xy" but the function rho( ) that is defined performs x + y. The code is below:
```
@kamodofy(units = 'kg/m**3', citation = 'Bob et. al, 2018', equation='xy')
def rho(x = np.array([3,4,5]), y = np.array([1,2,3])):
    """A function that computes density"""
    return x+y
```
I found this confusing when trying to understand what the wrapper does, and had to dig deeper to learn that the equation parameter determines the text displayed on the right side of the equation and has no impact on the math that is actually performed by the wrapped function. So I think it would be clearer to have it  show what the function is actually defined to perform, i.e. "x + y".